### PR TITLE
Rocket lists render

### DIFF
--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -1,6 +1,7 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import '../styles/rockets.css';
 import { getAPI } from '../redux/rocketsSlice';
 
 const RocketList = () => {

--- a/src/styles/rockets.css
+++ b/src/styles/rockets.css
@@ -1,0 +1,19 @@
+
+.rocketC {
+  display: flex;
+  margin: 10px;
+  margin-left: 70px;
+  margin-bottom: 30px;
+}
+
+.rocketImg {
+  width: 280px;
+}
+
+.contentC {
+  padding-right: 50px;
+  margin-left: 15px;
+}
+.rocketDesc {
+  font-size: large;
+}


### PR DESCRIPTION
- Use useSelector() Redux Hook to select the state slices and render lists of rockets in corresponding routes. i.e.:
- Get rockets data from the store
-  Use the useSelector
- Apply basic style.
- Render a list of rockets (as per design). For the image of a rocket use the first image in the array of flickr_images.